### PR TITLE
App Engine Python update to 2.7

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,12 +1,12 @@
 application: myappname
 version: 1
-runtime: python
+runtime: python27
 api_version: 1
 
 default_expiration: "5d"
 
-builtins:
-- datastore_admin: on
+#builtins:
+#- datastore_admin: on
 
 inbound_services:
 - warmup


### PR DESCRIPTION
Python 2.5 runtime will be disabled on App Engine.
On May 16th, 2017, the Python 2.5 runtime will be disabled on App Engine.
On June 20, 2017, the Python 2.5 runtime will be permanently disabled on App Engine.